### PR TITLE
Fix up File & Data Service docs

### DIFF
--- a/docs/for-developers/manage-data/README.md
+++ b/docs/for-developers/manage-data/README.md
@@ -51,7 +51,7 @@ While structured data is handled by the [Data Service](../../services/manage-dat
 
 #### Files <a href="#markdown-header-files" id="markdown-header-files"></a>
 
-The `files service` provides a way of storing data without imposing a structure on it by way of schemas. This means the `files service` allows the storage of a variety of file types with an unstructured content, such as images and streams. Storing a file with this service will return a _file token_, which can be used as a reference to that file for further interaction. The `files service` stores uploaded files together with metadata that describes the file, such as the name of the file, the file size and the file type.
+The `files service` provides a way of storing data without imposing a structure on it by way of schemas. This means the `files service` allows the storage of a variety of file types with unstructured content, such as images and streams. Storing a file with this service will return a _file token_, which can be used as a reference to that file for further interaction. The `files service` stores uploaded files together with metadata that describes the file, such as the name of the file, the file size and the file type.
 
 {% content-ref url="../../services/manage-data/file-service.md" %}
 [file-service.md](../../services/manage-data/file-service.md)

--- a/docs/services/manage-data/data-service/documents.md
+++ b/docs/services/manage-data/data-service/documents.md
@@ -59,7 +59,7 @@ const documents = await sdk.data.documents.find(schema.id, {
 Note that all custom properties defined in the schema will be under the `data` property of the document. You can query both on document properties and custom properties by using the dot notation in the RQL builder.
 
 {% hint style="warning" %}
-When queries take more than X milliseconds. The document service will stop the running query and respond with an error indicating the query took longer than the allowed limit.
+When queries take more than X milliseconds the document service will stop the running query and respond with an error indicating the query took longer than the allowed limit.
 
 To resolve this it is advised to add indexes on fields you use often in queries.
 {% endhint %}
@@ -75,12 +75,12 @@ await sdk.data.documents.update(schema.id, document.id, {
 ```
 
 {% hint style="info" %}
-As a good practice you can also add an RQL query when updating a document. This way you can guarantee you document is in a specific status or a fields holds a specific value and let the update fail it this is not the case.
+As a good practice you can also add an RQL query when updating a document. This way you can guarantee your document is in a specific status or a field holds a specific value and let the update fail if this is not the case.
 {% endhint %}
 
 ## Permanent delete
 
-While in many cases you will want to implement a `deleted` status to keep records of removed documents. In other cases you will want to remove a document from existence.
+While in many cases you will want to implement a `deleted` status to keep records of removed documents, in other cases you will want to remove a document from existence.
 
 ```javascript
 await sdk.data.documents.remove(schema.id,document.id);
@@ -106,11 +106,11 @@ When executing a transition you will need to provide the id of the transition th
 **Important!** If you set properties in `data` that correspond to properties in the document, the transition will update the record with the values from the `data` property.
 {% endhint %}
 
-## updating access
+## Updating access
 
-Access rules are defined in the schema and in many cases are dependent on the userIds and groupIds properties in the document root. These fields indicate to whom this specific document belongs to or has specific permissions over the document.
+Access rules are defined in the schema and in many cases are dependent on the `userIds` and `groupIds` properties in the document root. These fields indicate to whom this specific document belongs to or has specific permissions over the document.
 
-You can use the following functions to add or remove userIds and or groupIds from the document.
+You can use the following functions to add or remove userIds and / or groupIds from the document.
 
 {% tabs %}
 {% tab title="Linking Users" %}

--- a/docs/services/manage-data/data-service/faq-data-service.md
+++ b/docs/services/manage-data/data-service/faq-data-service.md
@@ -4,7 +4,7 @@
 
 ### How can I validate that an array does not contain a certain value in a transition condition?
 
-If it is an array of strings, you can use regex expressions. In the following schema definition, you can find an example of a validation where the tag important\_tag should not be present.
+If it is an array of strings, you can use regex expressions. In the following schema definition, you can find an example of a validation where the tag `important_tag` should not be present.
 
 The relevant regex expression is `^(?!important_tag$).+$`
 
@@ -115,7 +115,7 @@ Each code snippet shows the code in the condition configuration part of the sche
 If the array items are objects, you can remove an object by executing the following HTTP call:
 
 ```
-DELETE /data/v1/{{schema}}/documents/${schemaId}/{{arrayName}}/{{objectId}}
+DELETE /data/v1/{{schemaIdOrName}}/documents/${documentId}/{{arrayName}}/{{objectId}}
 ```
 
 If the array items are simple values, like strings or numbers, you have to execute a `PUT` to the record endpoint and provide the full array (leaving out the value that you want to remove).

--- a/docs/services/manage-data/data-service/schemas.md
+++ b/docs/services/manage-data/data-service/schemas.md
@@ -98,7 +98,7 @@ The following table lists the relevant permissions for the data service:
 | <p><code>CREATE_DOCUMENT_COMMENTS</code><br><code></code> <mark style="background-color:red;">deprecated</mark> </p>                                                                                                                                | A user with this permission can create comments in any document **in any schema**        |
 | <p><code>CREATE_DOCUMENT_COMMENTS:{schemaName}</code><br><code></code> <mark style="background-color:yellow;">since 1.1.0 </mark><em><mark style="background-color:yellow;"></mark></em> <mark style="background-color:red;">deprecated</mark> </p> | A user with this permission can create comments in any document in schema `schemaName`   |
 | <p><code>VIEW_DOCUMENT_COMMENTS</code><br><code></code> <mark style="background-color:red;">deprecated</mark> </p>                                                                                                                                  | A user with this permission can view comments in any document **in any schema**          |
-| <p><code>IEW_DOCUMENT_COMMENTS:{schemaName}</code><br><code></code> <mark style="background-color:yellow;">since 1.1.0</mark> <mark style="background-color:red;">deprecated</mark> </p>                                                            | A user with this permission can view comments in any document in schema `schemaName`     |
+| <p><code>VIEW_DOCUMENT_COMMENTS:{schemaName}</code><br><code></code> <mark style="background-color:yellow;">since 1.1.0</mark> <mark style="background-color:red;">deprecated</mark> </p>                                                            | A user with this permission can view comments in any document in schema `schemaName`     |
 | <p><code>UPDATE_DOCUMENT_COMMENTS</code><br><code></code> <mark style="background-color:red;">deprecated</mark> </p>                                                                                                                                | A user with this permission can update any document comments **in any schema**           |
 | <p><code>UPDATE_DOCUMENT_COMMENTS:{schemaName}</code><br><code></code> <mark style="background-color:yellow;">since 1.1.0</mark>  <mark style="background-color:red;">deprecated</mark> </p>                                                        | A user with this permission can update any document comments in schema `schemaName`      |
 | `UPDATE_ACCESS_TO_DOCUMENT`                                                                                                                                                                                                                         | A user with this permission can update the access to any document **in any schema**      |
@@ -125,7 +125,7 @@ const myNewSchema = await sdk.data.schemas.create({
 
 ## Properties
 
-A Schema defines the structure of a document through properties. The Properties object contains type configurations, which represent the fields which should be accepted while creating or updating a document. The structure of the type configurations themselves is inspired by [JSON Schema](https://json-schema.org).
+A Schema defines the structure of a document through properties. The Properties object contains type configurations, which represent the fields that should be accepted while creating or updating a document. The structure of the type configurations themselves is inspired by [JSON Schema](https://json-schema.org).
 
 ![](https://lh3.googleusercontent.com/FqZ0yp8aT6rAhz5rP69T6qCmNwwr3eE4EZoCDQQr4bEc1Poh8zrxg\_WiBjiuzqgpFDjYJL1ker6l4fM\_qVSIzBoSlyPrk60Mnte-ITj9PY583rMbQZVYCCJEe-QlyexcROsLmMY=s0)
 
@@ -335,7 +335,7 @@ All attributes required to compose the type configurations, can be found in the 
 
 ## Statuses
 
-A document can be perceived as a finite-state machine, which remains in a state/status until a transition occurs. You can define a set of statuses for you document based on the expected workflow you want to build.
+A document can be perceived as a finite-state machine, which remains in a state/status until a transition occurs. You can define a set of statuses for your document based on the expected workflow you want to build.
 
 {% tabs %}
 {% tab title="Javascript" %}
@@ -375,7 +375,7 @@ Currently the only supported transition type is `manual`. Other types may be add
 
 When you want to add more statuses to your document you will need to define transitions that allow you to move your document from one status to another. Normal transitions look the same as a creationTransition but these do include two additional parameters `fromStatuses`and `name`.
 
-A Transition occurs from one Status to another. The Statuses a Transition starts from are determined in the fromStatuses object, and the Status the Transition leads to is determined in the toStatus attribute.
+A Transition occurs from one Status to another. The Statuses a Transition starts from are determined in the `fromStatuses` object, and the Status the Transition leads to is determined in the `toStatus` attribute.
 
 {% tabs %}
 {% tab title="Javascript" %}
@@ -454,6 +454,8 @@ When executing a transition on a document you can require the API client to prov
 the example above would require the API client to provide the address.inhabited property. otherwise the transition will not trigger.
 {% endtab %}
 
+<!-- Remaining examples are redundant or not filled out -->
+
 {% tab title="document" %}
 ```javascript
   await sdk.data.transitions.create(newSchema.id, {
@@ -511,7 +513,7 @@ You can attach actions to transitions. This way when a transition is executed an
 To access an element in an array or embedded documents, use the dot notation.
 {% endhint %}
 
-### **Modifying document access**
+#### **Modifying document access**
 
 Each document has a `userIds` and `groupIds` field. These field are part of determining the access policy towards that specific document depending on the general collection schema configuration.
 
@@ -552,7 +554,7 @@ await sdk.data.transitions.create(newSchema.id, {
   actions: [
     {
       type: 'linkUserFromData',
-      userIdField: '{UserIdField}', // Field in dot notation.The root is data
+      userIdField: '{UserIdField}', // Field in dot notation. The root is data
     }
   ],
   ...
@@ -566,7 +568,7 @@ await sdk.data.transitions.create(newSchema.id, {
   ...,
   actions: [
     {
-      type: 'LinkEnlistedGroups',
+      type: 'linkEnlistedGroups',
       onlyActive: true, // Optional, defaults to false
     }
   ],
@@ -582,7 +584,7 @@ await sdk.data.transitions.create(newSchema.id, {
   actions: [
     {
       type: 'linkGroupFromData',
-      groupIdField: 'my_group_id', // Field in dot notation.The root is data
+      groupIdField: 'my_group_id', // Field in dot notation. The root is data
     }
   ],
   ...
@@ -615,14 +617,13 @@ await sdk.data.transitions.create(newSchema.id, {
 ```
 {% endtab %}
 
-{% tab title="Second Tab" %}
-
-{% endtab %}
 {% endtabs %}
 
 ## Indexes
 
 The Index object is identified by an id and a name. An index is set on a specific property in a Schema. This property is defined in the Fields object by the name and type attribute. The index is tailored with the following attributes:
+
+<!-- Some attributes are not described -->
 
 | Attribute  | Description                                                   |
 | ---------- | ------------------------------------------------------------- |
@@ -705,7 +706,7 @@ await sdk.data.schemas.enable('{yourSchemaId}');
 
 ### **Enabling/disabling a schema**
 
-As the removal of a schema is something that you want to handle with great care the service first requires you to disable a schema. When a schema is disabled creation of new documents is disabled and no changes are allow to existing documents.
+As the removal of a schema is something that you want to handle with great care the service first requires you to disable a schema. When a schema is disabled creation of new documents is disabled and no changes are allowed to existing documents.
 
 ```javascript
 await sdk.data.schemas.disable('{yourSchemaId}');

--- a/docs/services/manage-data/file-service.md
+++ b/docs/services/manage-data/file-service.md
@@ -192,7 +192,7 @@ In the request to delete a token, `token` and `tokenToDelete` can have the same 
 
 ## List uploaded files
 
-This request provides a list of the available FileMetadata objects, including the corresponding tokens. It can be used by an administrator, for example to regain access to a File when tokens are lost. This request provides a list of the available FileMetadata objects, including the corresponding tokens. It can be used by an administrator to regain access to a File when tokens are lost.
+This request provides a list of the available FileMetadata objects, including the corresponding tokens. It can be used by an administrator, for example to regain access to a File when tokens are lost. 
 
 {% hint style="warning" %}
 Retrieving a list of uploaded files is only intended for Administrator use. Only users with the global VIEW\_FILES permission can use the following functions.


### PR DESCRIPTION
Found some typos, grammar errors and redundant lines while reading the documentation. Decided to chip in.

Left some comments in places where there was something missing, like examples of code or descriptions. To be deleted once addressed.